### PR TITLE
Fix surround viopp wrapper

### DIFF
--- a/functions/-viopp-wrapper
+++ b/functions/-viopp-wrapper
@@ -1,7 +1,5 @@
 local key
-if ((! REGION_ACTIVE)); then
-	read -k 1 key
-fi
+read -k 1 key
 
 if [[ $key = 's' ]]; then
 	case ${WIDGET#zvmm-} in

--- a/functions/-viopp-wrapper
+++ b/functions/-viopp-wrapper
@@ -1,5 +1,8 @@
 local key
-read -k 1 key
+if ((! REGION_ACTIVE)); then
+	read -k 1 key
+fi
+
 if [[ $key = 's' ]]; then
 	case ${WIDGET#zvmm-} in
 		vi-change*) zle change-surround -w ;;

--- a/motions.zsh
+++ b/motions.zsh
@@ -53,6 +53,7 @@ zle -N zvmm-vi-yank     -viopp-wrapper
 zle -N zvmm-push-string -viopp-wrapper-push-string
 
 bindkey -M vicmd c zvmm-vi-change d zvmm-vi-delete y zvmm-vi-yank
+bindkey -M visual c vi-change d vi-delete y vi-yank
 bindkey -M visual S add-surround
 
 # Add forward/backwards widgets


### PR DESCRIPTION
-viopp-wrapper always reads key, breaking `d`/`c`/`y` commands on selection (e.g. `viwc`)

fix this so that when a selection has been made (i.e. `REGION_ACTIVE`), we go to the zle passthrough case